### PR TITLE
add right license in copyright statement in the rendered jupyter book

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,3 +19,10 @@ repository:
 html:
   use_issues_button: true
   use_repository_button: true
+  extra_footer: |
+    <p>
+    Copyright: This work can be reused under the terms of the <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC-BY 4.0</a> license unless mentioned otherwise.
+    </p>
+sphinx:
+  config:
+    html_show_copyright: false


### PR DESCRIPTION
This modifies the rendered jupyter book so that it says in the footer "This work can be reused under the terms of the CC-BY..." instead of just "Copyright (C)"