### PR TITLE
Add vedo and points-and-surfaces install instruction

### DIFF
--- a/docs/day2c_feature_extraction/02_sphericity_and_solidity.ipynb
+++ b/docs/day2c_feature_extraction/02_sphericity_and_solidity.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "<https://drive.google.com/file/d/1zywDJeNinfoJC49qFuskqxQ4HGniGSGK/view?usp=sharing>\n",
     "\n",
-    "You should not need a password.You will need to have [napari-process-points-and-surfaces](https://www.napari-hub.org/plugins/napari-process-points-and-surfaces) and the [vedo library](https://vedo.embl.es/) installed. They should already be part of your `devbio-napari-env`.\n",
+    "You should not need a password. You will need to have [napari-process-points-and-surfaces](https://www.napari-hub.org/plugins/napari-process-points-and-surfaces) and the [vedo library](https://vedo.embl.es/) installed. They should already be part of your `devbio-napari-env`. If they are not, you can add them using `mamba install napari-process-points-and-surfaces` and `mamba install vedo`\n",
     "\n",
     "The data used in this notebook is derived from [AV Luque and JV Veenvliet (2023)](https://zenodo.org/record/7603081) licensed [CC-BY](https://creativecommons.org/licenses/by/4.0/legalcode) and can be downloaded from here: https://zenodo.org/record/7603081. Compared to the original, the file used here is binary to reduce file size."
    ]


### PR DESCRIPTION
I figured out that napari-process-points-and-surfaces-is not part of devbio-napari. Therefore, I am adding mamba install commands for this. And for the sake of completeness also for vedo.